### PR TITLE
Allow for large integers in docs_bulk.

### DIFF
--- a/R/docs_bulk.r
+++ b/R/docs_bulk.r
@@ -199,7 +199,7 @@ docs_bulk.character <- function(x, index = NULL, type = NULL, chunk_size = 1000,
 }
 
 make_bulk <- function(df, index, type, counter) {
-  metadata_fmt <- '{"index":{"_index":"%s","_type":"%s","_id":%d}}'
+  metadata_fmt <- '{"index":{"_index":"%s","_type":"%s","_id":%s}}'
   metadata <- sprintf(metadata_fmt, index, type, counter - 1L)
   data <- jsonlite::toJSON(df, collapse = FALSE)
   tmpf <- tempfile("elastic__")

--- a/R/docs_bulk.r
+++ b/R/docs_bulk.r
@@ -200,7 +200,7 @@ docs_bulk.character <- function(x, index = NULL, type = NULL, chunk_size = 1000,
 
 make_bulk <- function(df, index, type, counter) {
   metadata_fmt <- '{"index":{"_index":"%s","_type":"%s","_id":%s}}'
-  metadata <- sprintf(metadata_fmt, index, type, counter - 1L)
+  metadata <- sprintf(metadata_fmt, index, type, counter)
   data <- jsonlite::toJSON(df, collapse = FALSE)
   tmpf <- tempfile("elastic__")
   writeLines(paste(metadata, data, sep = "\n"), tmpf)


### PR DESCRIPTION
sprintf's %d doesn't allow for large integers. Using the %s type instead keeps the value as as integer in the output string. I had to remove "counter - 1L" since the input is a character vector now.

Just a quick workaround. Hope you find a better solution.