### PR TITLE
correct a bug: has_http not return altered object

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -81,6 +81,7 @@ has_http <- function(x) {
   if (!grepl("^http[s]?://", x)) {
     x <- paste0("http://", x)
     message("es_base not prefixed with http, using ", x, "\nIf you need https, pass in the complete URL")
+    x
   } else {
     x
   }


### PR DESCRIPTION
There is a bug concerning the `has_http` function.
Where argument `es_base` has a value not containing "http://", it will prefix it but the altered string is never returned. Instead, a NULL is returned so the entire `connect` method will fall back to use the default value of "http://127.0.0.1".