### PR TITLE
fix JSON format for list input

### DIFF
--- a/R/docs_bulk_utils.R
+++ b/R/docs_bulk_utils.R
@@ -21,7 +21,7 @@ make_bulk <- function(df, index, type, counter, es_ids, path = NULL) {
     type,
     counter
   )
-  data <- jsonlite::toJSON(df, collapse = FALSE)
+  data <- jsonlite::toJSON(df, collapse = FALSE, na = "null", auto_unbox = TRUE)
   tmpf <- if (is.null(path)) tempfile("elastic__") else path
   writeLines(paste(metadata, data, sep = "\n"), tmpf)
   invisible(tmpf)


### PR DESCRIPTION
This fixes some issues I had with the JSON produced in `make_bulk()` for list input:

- `NA` becomes `"NA"` which is an issue particularly for non character fields
- atomic vectors are not unboxed

This may break things for other users, please evaluate.