### PR TITLE
update write function ( utf8 encoding)

### DIFF
--- a/R/docs_bulk_update.R
+++ b/R/docs_bulk_update.R
@@ -119,6 +119,6 @@ make_bulk_update <- function(df, index, type, counter, path = NULL) {
 
   data <- lapply(tmp, jsonlite::toJSON, na = "null", auto_unbox = TRUE)
   tmpf <- if (is.null(path)) tempfile("elastic__") else path
-  writeLines(paste(metadata, data, sep = "\n"), tmpf)
+  write_utf8(paste(metadata, data, sep = "\n"), tmpf)
   invisible(tmpf)
 }

--- a/R/docs_bulk_utils.R
+++ b/R/docs_bulk_utils.R
@@ -23,7 +23,7 @@ make_bulk <- function(df, index, type, counter, es_ids, path = NULL) {
   )
   data <- jsonlite::toJSON(df, collapse = FALSE, na = "null", auto_unbox = TRUE)
   tmpf <- if (is.null(path)) tempfile("elastic__") else path
-  writeLines(paste(metadata, data, sep = "\n"), tmpf)
+  write_utf8(paste(metadata, data, sep = "\n"), tmpf)
   invisible(tmpf)
 }
 

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -157,3 +157,15 @@ assert <- function(x, y) {
     }
   }
 }
+
+
+write_utf8 = function(text, con, ...) {
+  if (identical(con, '')) {
+    cat(text, sep = '\n', file = con)
+  } else {
+    # prevent re-encoding the text in the file() connection in writeLines()
+    # https://kevinushey.github.io/blog/2018/02/21/string-encoding-and-r/
+    opts = options(encoding = 'native.enc'); on.exit(options(opts), add = TRUE)
+    writeLines(enc2utf8(text), con, ..., useBytes = TRUE)
+  }
+}


### PR DESCRIPTION

fix encoding write function in UTF-8


## Related Issue

#223

## Example

```r
library(elastic)
connect()

a = data.frame(a= '测试', b = 123)
elastic::index_create(index = "test", verbose = TRUE)
elastic::docs_bulk(a, index = "dianping")
```

```r
[[1]]
[[1]]$took
[1] 22

[[1]]$errors
[1] FALSE

[[1]]$items
[[1]]$items[[1]]
[[1]]$items[[1]]$index
[[1]]$items[[1]]$index$`_index`
[1] "dianping"

[[1]]$items[[1]]$index$`_type`
[1] "dianping"

[[1]]$items[[1]]$index$`_id`
[1] "bmU7F2QBfgMgeBf7JQoo"

[[1]]$items[[1]]$index$`_version`
[1] 1

[[1]]$items[[1]]$index$result
[1] "created"

[[1]]$items[[1]]$index$`_shards`
[[1]]$items[[1]]$index$`_shards`$total
[1] 2

[[1]]$items[[1]]$index$`_shards`$successful
[1] 1

[[1]]$items[[1]]$index$`_shards`$failed
[1] 0


[[1]]$items[[1]]$index$`_seq_no`
[1] 1946

[[1]]$items[[1]]$index$`_primary_term`
[1] 1

[[1]]$items[[1]]$index$status
[1] 201
```