### PR TITLE
Rectified error in example description.

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -219,7 +219,7 @@ Search(index = "plos", type = "article", q = "antibody", size = 1)$hits$hits
 
 ## Get documents
 
-Get document with id=1
+Get document with id=4
 
 ```{r}
 docs_get(index = 'plos', type = 'article', id = 4)

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Search(index = "plos", type = "article", q = "antibody", size = 1)$hits$hits
 
 ## Get documents
 
-Get document with id=1
+Get document with id=4
 
 
 ```r


### PR DESCRIPTION
Rectified error in `_id` number; example shows `_id == 4`, description states `_id == 1`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Example description states that records where `_id == 1` will be searched but example showed `_id == 4`.  I changed the description to match the example as this was clearly a mistake in the description and not in the example.