### PR TITLE
Removed incorrect id reference in example.

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -219,7 +219,7 @@ Search(index = "plos", type = "article", q = "antibody", size = 1)$hits$hits
 
 ## Get documents
 
-Get document with id=1
+Get document with id=4
 
 ```{r}
 docs_get(index = 'plos', type = 'article', id = 4)


### PR DESCRIPTION
Changed example text from `id=1` to `id=4` to match the example output.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed incorrect example text to match example output.