### PR TITLE
Fix bulk update with bool field

### DIFF
--- a/R/docs_bulk_update.R
+++ b/R/docs_bulk_update.R
@@ -111,10 +111,10 @@ make_bulk_update <- function(df, index, type, counter, path = NULL) {
     counter
   )
   
-  tmp <- apply(df, 1, as.list)
-  tmp <- lapply(unname(tmp), function(z) {
-    z$id <- NULL
-    list(doc = z, doc_as_upsert = TRUE)
+  tmp <- lapply(1:nrow(df), function(i) {
+    r <- df[i,]
+    r$id <- NULL
+    list(doc = as.list(r), doc_as_upsert = TRUE)
   })
 
   data <- lapply(tmp, jsonlite::toJSON, na = "null", auto_unbox = TRUE)

--- a/R/docs_bulk_update.R
+++ b/R/docs_bulk_update.R
@@ -111,13 +111,13 @@ make_bulk_update <- function(df, index, type, counter, path = NULL) {
     counter
   )
   
-  tmp <- lapply(seq_len(nrow(df)), function(i) {
-    r <- df[i,]
-    r$id <- NULL
-    list(doc = as.list(r), doc_as_upsert = TRUE)
+  df$id <- NULL
+  
+  data <- lapply(seq_len(nrow(df)), function(i) {
+    z <- list(doc = unbox(df[i,]), doc_as_upsert = TRUE)
+    jsonlite::toJSON(z, auto_unbox = TRUE, na = "null", null = "null")
   })
 
-  data <- lapply(tmp, jsonlite::toJSON, na = "null", auto_unbox = TRUE)
   tmpf <- if (is.null(path)) tempfile("elastic__") else path
   write_utf8(paste(metadata, data, sep = "\n"), tmpf)
   invisible(tmpf)

--- a/R/docs_bulk_update.R
+++ b/R/docs_bulk_update.R
@@ -114,7 +114,7 @@ make_bulk_update <- function(df, index, type, counter, path = NULL) {
   df$id <- NULL
   
   data <- lapply(seq_len(nrow(df)), function(i) {
-    z <- list(doc = unbox(df[i,]), doc_as_upsert = TRUE)
+    z <- list(doc = jsonlite::unbox(df[i,]), doc_as_upsert = TRUE)
     jsonlite::toJSON(z, auto_unbox = TRUE, na = "null", null = "null")
   })
 

--- a/R/docs_bulk_update.R
+++ b/R/docs_bulk_update.R
@@ -111,7 +111,7 @@ make_bulk_update <- function(df, index, type, counter, path = NULL) {
     counter
   )
   
-  tmp <- lapply(1:nrow(df), function(i) {
+  tmp <- lapply(seq_len(nrow(df)), function(i) {
     r <- df[i,]
     r$id <- NULL
     list(doc = as.list(r), doc_as_upsert = TRUE)


### PR DESCRIPTION
Fixes #239: In `docs_bulk_update` boolean fields get cast as strings. Just need to run `as.list` on each data.frame row, not on the entire data.frame.