### PR TITLE
track_total_hits in request for elastic >= 7.0

### DIFF
--- a/R/Search_uri.R
+++ b/R/Search_uri.R
@@ -14,7 +14,7 @@ Search_uri <- function(conn, index=NULL, type=NULL, q=NULL, df=NULL, analyzer=NU
   default_operator=NULL, explain=NULL, source=NULL, fields=NULL, sort=NULL,
   track_scores=NULL, timeout=NULL, terminate_after=NULL, from=NULL, size=NULL,
   search_type=NULL, lowercase_expanded_terms=NULL, analyze_wildcard=NULL,
-  version=NULL, lenient=FALSE, raw=FALSE, asdf=FALSE,
+  version=NULL, lenient=FALSE, raw=FALSE, asdf=FALSE, track_total_hits = TRUE,
   search_path="_search", stream_opts=list(), ...) {
 
   is_conn(conn)
@@ -27,7 +27,7 @@ Search_uri <- function(conn, index=NULL, type=NULL, q=NULL, df=NULL, analyzer=NU
       search_type = search_type,
       lowercase_expanded_terms = lowercase_expanded_terms,
       analyze_wildcard = analyze_wildcard, version = as_log(version), q = q,
-      lenient = as_log(lenient))), raw, asdf, stream_opts, ...)
+      lenient = as_log(lenient), track_total_hits = ck(track_total_hits))), raw, asdf, stream_opts, ...)
 }
 
 search_GET <- function(conn, path, index=NULL, type=NULL, args, raw, asdf, 
@@ -35,6 +35,8 @@ search_GET <- function(conn, path, index=NULL, type=NULL, args, raw, asdf,
   url <- conn$make_url()
   url <- construct_url(url, path, index, type)
   url <- prune_trailing_slash(url)
+  # track_total_hits introduced in ES >= 7.0
+  if (conn$es_ver() < 700) args$track_total_hits <- NULL
   # in ES >= v5, lenient param droppped
   if (conn$es_ver() >= 500) args$lenient <- NULL
   # in ES >= v5, fields param changed to stored_fields

--- a/R/search.r
+++ b/R/search.r
@@ -20,7 +20,7 @@ Search <- function(conn, index=NULL, type=NULL, q=NULL, df=NULL, analyzer=NULL,
   default_operator=NULL, explain=NULL, source=NULL, fields=NULL, sort=NULL, 
   track_scores=NULL, timeout=NULL, terminate_after=NULL, from=NULL, size=NULL, 
   search_type=NULL, lowercase_expanded_terms=NULL, analyze_wildcard=NULL, 
-  version=NULL, lenient=FALSE, body=list(), raw=FALSE, asdf=FALSE, 
+  version=NULL, lenient=FALSE, body=list(), raw=FALSE, asdf=FALSE, track_total_hits = TRUE,
   time_scroll=NULL, search_path="_search", stream_opts=list(), ...) {
 
   is_conn(conn)
@@ -33,7 +33,7 @@ Search <- function(conn, index=NULL, type=NULL, q=NULL, df=NULL, analyzer=NULL,
       search_type = search_type, 
       lowercase_expanded_terms = lowercase_expanded_terms, 
       analyze_wildcard = analyze_wildcard, version = as_log(version), q = q, 
-      scroll = time_scroll, lenient = as_log(lenient))), body, raw, asdf, 
+      scroll = time_scroll, lenient = as_log(lenient), track_total_hits = ck(track_total_hits))), body, raw, asdf,
     stream_opts, ...)
   if (!is.null(time_scroll)) attr(tmp, "scroll") <- time_scroll
   return(tmp)
@@ -52,6 +52,8 @@ search_POST <- function(conn, path, index=NULL, type=NULL, args, body, raw,
   url <- construct_url(url, path, index, type)
   url <- prune_trailing_slash(url)
   body <- check_inputs(body)
+  # track_total_hits introduced in ES >= 7.0
+  if (conn$es_ver() < 700) args$track_total_hits <- NULL
   # in ES >= v5, lenient param droppped
   if (conn$es_ver() >= 500) args$lenient <- NULL
   # in ES >= v5, fields param changed to stored_fields

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -8,6 +8,14 @@ as_log <- function(x){
   }
 }
 
+ck <- function(x){
+  if (is.null(x) || is.numeric(x)) {
+    x
+  } else if (is.logical(x)) {
+    as_log(x)
+  }
+}
+
 `%|||%` <- function(x, y) if (x == "false") y else x
 
 cl <- function(x) if (is.null(x)) NULL else paste0(x, collapse = ",")

--- a/man-roxygen/search_par.r
+++ b/man-roxygen/search_par.r
@@ -58,9 +58,13 @@
 #' @param analyze_wildcard (logical) Should wildcard and prefix queries be 
 #' analyzed or not. Default: \code{FALSE}.
 #' @param version (logical) Print the document version with each document.
-#' @param lenient If \code{TRUE} will cause format based failures (like 
+#' @param lenient (logical) If \code{TRUE} will cause format based failures (like 
 #' providing text to a numeric field) to be ignored. Default: \code{FALSE}
-#' @param raw (logical) If \code{FALSE} (default), data is parsed to list. 
+#' @param track_total_hits (logical, numeric) If \code{TRUE} will always track 
+#' the number of hits that match the query accurately. If \code{FALSE} will 
+#' count documents accurately up to 10000 documents. If \code{is.integer} will 
+#' count documents accurately up to the number. Default: \code{TRUE}
+#' @param raw (logical) If \code{FALSE} (default), data is parsed to list.
 #' If \code{TRUE}, then raw JSON returned
 #' @param asdf (logical) If \code{TRUE}, use \code{\link[jsonlite]{fromJSON}} 
 #' to parse JSON directly to a data.frame. If \code{FALSE} (Default), list 


### PR DESCRIPTION
Adding track_total_hits param in a request. As it's the only way how to get exact counts using the Search function. https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-track-total-hits.html

Unfortunately, I didn't test it much, but I hope it's ok as it's simple.

I had an assumption that this parameter was introduced with elasticsearch 7.0.