### PR TITLE
Adding the tag for docker pul

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -64,13 +64,14 @@ __w/ Docker__
 Pull the official elasticsearch image
 
 ```
-docker pull elasticsearch
+# elasticsearch needs to have a version tag. We're pulling 7.10.1 here
+docker pull elasticsearch:7.10.1
 ```
 
 Then start up a container
 
 ```
-docker run -d -p 9200:9200 elasticsearch
+docker run -d -p 9200:9200 elasticsearch:7.10.1
 ```
 
 Then elasticsearch should be available on port 9200, try `curl localhost:9200` and you should get the familiar message indicating ES is on.

--- a/README.md
+++ b/README.md
@@ -60,13 +60,14 @@ __w/ Docker__
 Pull the official elasticsearch image
 
 ```
-docker pull elasticsearch
+# elasticsearch needs to have a version tag. We're pulling 7.10.1 here
+docker pull elasticsearch:7.10.1
 ```
 
 Then start up a container
 
 ```
-docker run -d -p 9200:9200 elasticsearch
+docker run -d -p 9200:9200 elasticsearch:7.10.1
 ```
 
 Then elasticsearch should be available on port 9200, try `curl localhost:9200` and you should get the familiar message indicating ES is on.


### PR DESCRIPTION
elasticsearch docker images don't have a "latest" tag, so the code in the README isn't reproducible.
This change adds a tag to the docker pull and run commands.

https://hub.docker.com/_/elasticsearch?tab=tags