### PR TITLE
Consider ignore version on scroll

### DIFF
--- a/R/scroll.R
+++ b/R/scroll.R
@@ -249,13 +249,15 @@ scroll.character <- function(conn, x, time_scroll = "1m", raw = FALSE, asdf = FA
   calls <- names(list(...))
   if ("scroll" %in% calls) {
     stop("The parameter `scroll` has been removed - use `time_scroll`")
-  }
-  if (conn$es_ver() < 200) {
-    body <- x
-    args <- list(scroll = time_scroll)
-  } else {
-    body <- list(scroll = time_scroll, scroll_id = x)
-    args <- list()
+  }  
+  if (!conn$ignore_version){
+    if (conn$es_ver() < 200) {
+      body <- x
+      args <- list(scroll = time_scroll)
+    } else {
+      body <- list(scroll = time_scroll, scroll_id = x)
+      args <- list()
+    }
   }
   tmp <- scroll_POST(
     conn = conn,


### PR DESCRIPTION
This change will make scroll consider the ignore_version option from the connection.