### PR TITLE
Use jsonlite sf support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     utils,
     curl (>= 2.2),
     crul (>= 0.9.0),
-    jsonlite (>= 1.7.0),
+    jsonlite,
     R6
 Suggests:
     testthat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     utils,
     curl (>= 2.2),
     crul (>= 0.9.0),
-    jsonlite (>= 1.1),
+    jsonlite (>= 1.7.0),
     R6
 Suggests:
     testthat

--- a/R/bulk_ci_generator.R
+++ b/R/bulk_ci_generator.R
@@ -15,7 +15,7 @@ make_bulk_ <- function(df, index, counter, es_ids, type = NULL, path = NULL,
     sprintf(metadata_fmt, action, index, counter)
   }
   data <- jsonlite::toJSON(df, collapse = FALSE, na = "null",
-    auto_unbox = TRUE, digits = digits)
+    auto_unbox = TRUE, digits = digits, sf = "features")
   tmpf <- if (is.null(path)) tempfile("elastic__") else path
   write_utf8(paste(metadata, data, sep = "\n"), tmpf)
   invisible(tmpf)

--- a/R/bulk_ci_generator.R
+++ b/R/bulk_ci_generator.R
@@ -1,5 +1,5 @@
 make_bulk_ <- function(df, index, counter, es_ids, type = NULL, path = NULL,
-  action = "index", digits = NA) {
+  action = "index", digits = NA, sf = NULL) {
 
   if (!is.character(counter)) {
     if (max(counter) >= 10000000000) {
@@ -15,7 +15,7 @@ make_bulk_ <- function(df, index, counter, es_ids, type = NULL, path = NULL,
     sprintf(metadata_fmt, action, index, counter)
   }
   data <- jsonlite::toJSON(df, collapse = FALSE, na = "null",
-    auto_unbox = TRUE, digits = digits, sf = "features")
+    auto_unbox = TRUE, digits = digits, sf = sf)
   tmpf <- if (is.null(path)) tempfile("elastic__") else path
   write_utf8(paste(metadata, data, sep = "\n"), tmpf)
   invisible(tmpf)
@@ -24,7 +24,7 @@ make_bulk_ <- function(df, index, counter, es_ids, type = NULL, path = NULL,
 bulk_ci_generator <- function(action = "index", es_ids = TRUE) {
   tt <- function(conn, x, index = NULL, type = NULL, chunk_size = 1000,
     doc_ids = NULL, es_ids = TRUE, raw = FALSE, quiet = FALSE,
-    query = list(), digits = NA, ...) {
+    query = list(), digits = NA, sf = NULL, ...) {
 
     is_conn(conn)
     assert(quiet, "logical")
@@ -57,7 +57,7 @@ bulk_ci_generator <- function(action = "index", es_ids = TRUE) {
       if (!quiet) setTxtProgressBar(pb, i)
       resl[[i]] <- docs_bulk(conn,
         make_bulk_(x[data_chks[[i]], , drop = FALSE],
-        index, id_chks[[i]], es_ids, type, action = action, digits = digits),
+        index, id_chks[[i]], es_ids, type, action = action, digits = digits, sf = sf),
         query = query, ...)
     }
     return(resl)

--- a/R/bulk_df_fun_generator.R
+++ b/R/bulk_df_fun_generator.R
@@ -1,8 +1,8 @@
 make_bulk_df_generator <- function(fun) {
-  function(conn, x, index = NULL, type = NULL, chunk_size = 1000, 
+  function(conn, x, index = NULL, type = NULL, chunk_size = 1000,
     doc_ids = NULL, raw = FALSE, quiet = FALSE, query = list(),
-    digits = NA, ...) {
-  
+    digits = NA, sf = NULL, ...) {
+
     is_conn(conn)
     assert(quiet, "logical")
     if (is.null(index)) {
@@ -10,7 +10,7 @@ make_bulk_df_generator <- function(fun) {
            call. = FALSE)
     }
     check_doc_ids(x, doc_ids)
-    # make sure document ids passed 
+    # make sure document ids passed
     if (!'id' %in% names(x) && is.null(doc_ids)) {
       stop('data.frame must have a column "id" or pass param "doc_ids"')
     }
@@ -29,15 +29,15 @@ make_bulk_df_generator <- function(fun) {
     }
 
     if (!quiet) {
-      pb <- txtProgressBar(min = 0, max = length(data_chks), 
+      pb <- txtProgressBar(min = 0, max = length(data_chks),
         initial = 0, style = 3)
       on.exit(close(pb))
     }
     resl <- vector(mode = "list", length = length(data_chks))
     for (i in seq_along(data_chks)) {
       if (!quiet) setTxtProgressBar(pb, i)
-      resl[[i]] <- docs_bulk(conn, fun(x[data_chks[[i]], , drop = FALSE], 
-        index, id_chks[[i]], type, digits = digits), query = query, ...)
+      resl[[i]] <- docs_bulk(conn, fun(x[data_chks[[i]], , drop = FALSE],
+        index, id_chks[[i]], type, digits = digits, sf = sf), query = query, ...)
     }
     return(resl)
   }

--- a/R/docs_bulk_delete.R
+++ b/R/docs_bulk_delete.R
@@ -2,7 +2,7 @@
 #'
 #' @export
 #' @inheritParams docs_bulk
-#' @param digits ignored, used in other docs bulk functions but not used here
+#' @param digits,sf ignored, used in other docs bulk functions but not used here
 #' @details
 #'
 #' For doing deletes with a file already prepared for the bulk API,
@@ -34,7 +34,7 @@
 #' }
 docs_bulk_delete <- function(conn, x, index = NULL, type = NULL,
   chunk_size = 1000, doc_ids = NULL, raw = FALSE, quiet = FALSE,
-  query = list(), digits = NA, ...) {
+  query = list(), digits = NA, sf = NULL, ...) {
 
   UseMethod("docs_bulk_delete", x)
 }
@@ -42,7 +42,7 @@ docs_bulk_delete <- function(conn, x, index = NULL, type = NULL,
 #' @export
 docs_bulk_delete.default <- function(conn, x, index = NULL, type = NULL,
   chunk_size = 1000, doc_ids = NULL, raw = FALSE, quiet = FALSE,
-  query = list(), digits = NA, ...) {
+  query = list(), digits = NA, sf = NULL, ...) {
 
   stop("no 'docs_bulk_delete' method for class ", class(x)[[1L]],
     call. = FALSE)
@@ -53,8 +53,8 @@ docs_bulk_delete.data.frame <- make_bulk_df_generator(make_bulk_delete)
 
 # helpers
 make_bulk_delete <- function(df, index, counter, type = NULL, path = NULL,
-  digits = NULL) {
-  # digits is ignored within this function
+  digits = NULL, sf = NULL) {
+  # digits,sf is ignored within this function
 
   if (!is.character(counter)) {
     if (max(counter) >= 10000000000) {

--- a/R/docs_bulk_index.R
+++ b/R/docs_bulk_index.R
@@ -1,25 +1,25 @@
 #' Use the bulk API to index documents
-#' 
+#'
 #' @export
 #' @inheritParams docs_bulk
-#' @details 
-#' 
-#' For doing index with a file already prepared for the bulk API, 
+#' @details
+#'
+#' For doing index with a file already prepared for the bulk API,
 #' see [docs_bulk()]
-#' 
+#'
 #' Only data.frame's are supported for now.
 #' @family bulk-functions
-#' @references 
+#' @references
 #' <https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html>
 #' @examples \dontrun{
 #' x <- connect()
 #' if (index_exists(x, "foobar")) index_delete(x, "foobar")
-#' 
+#'
 #' df <- data.frame(name = letters[1:3], size = 1:3, id = 100:102)
 #' docs_bulk_index(x, df, 'foobar')
 #' docs_bulk_index(x, df, 'foobar', es_ids = FALSE)
 #' Search(x, "foobar", asdf = TRUE)$hits$hits
-#' 
+#'
 #' # more examples
 #' docs_bulk_index(x, mtcars, index = "hello")
 #' ## field names cannot contain dots
@@ -33,17 +33,17 @@
 #' }
 docs_bulk_index <- function(conn, x, index = NULL, type = NULL,
   chunk_size = 1000, doc_ids = NULL, es_ids = TRUE, raw = FALSE, quiet = FALSE,
-  query = list(), digits = NA, ...) {
-  
+  query = list(), digits = NA, sf = NULL, ...) {
+
   UseMethod("docs_bulk_index", x)
 }
 
 #' @export
-docs_bulk_index.default <- function(conn, x, index = NULL, type = NULL, 
-  chunk_size = 1000, doc_ids = NULL, es_ids = TRUE, raw = FALSE, 
-  quiet = FALSE, query = list(), digits = NA, ...) {
-  
-  stop("no 'docs_bulk_index' method for class ", class(x)[[1L]], 
+docs_bulk_index.default <- function(conn, x, index = NULL, type = NULL,
+  chunk_size = 1000, doc_ids = NULL, es_ids = TRUE, raw = FALSE,
+  quiet = FALSE, query = list(), digits = NA, sf = NULL, ...) {
+
+  stop("no 'docs_bulk_index' method for class ", class(x)[[1L]],
     call. = FALSE)
 }
 

--- a/R/docs_bulk_update.R
+++ b/R/docs_bulk_update.R
@@ -87,7 +87,7 @@ make_bulk_update <- function(df, index, counter, type = NULL, path = NULL,
   data <- lapply(seq_len(nrow(df)), function(i) {
     z <- list(doc = jsonlite::unbox(df[i,,drop=FALSE]), doc_as_upsert = TRUE)
     jsonlite::toJSON(z, auto_unbox = TRUE, na = "null", null = "null",
-      digits = digits)
+      digits = digits, sf = "features")
   })
 
   tmpf <- if (is.null(path)) tempfile("elastic__") else path

--- a/R/docs_bulk_update.R
+++ b/R/docs_bulk_update.R
@@ -36,8 +36,8 @@
 #' Search(x, "foobar", asdf = TRUE)$hits$hits
 #' }
 docs_bulk_update <- function(conn, x, index = NULL, type = NULL,
-  chunk_size = 1000, doc_ids = NULL, raw = FALSE, quiet = FALSE, 
-  query = list(), digits = NA, ...) {
+  chunk_size = 1000, doc_ids = NULL, raw = FALSE, quiet = FALSE,
+  query = list(), digits = NA, sf = NULL, ...) {
 
   UseMethod("docs_bulk_update", x)
 }
@@ -45,7 +45,7 @@ docs_bulk_update <- function(conn, x, index = NULL, type = NULL,
 #' @export
 docs_bulk_update.default <- function(conn, x, index = NULL, type = NULL,
   chunk_size = 1000, doc_ids = NULL, raw = FALSE, quiet = FALSE,
-  query = list(), digits = NA, ...) {
+  query = list(), digits = NA, sf = NULL, ...) {
 
   stop("no 'docs_bulk_update' method for class ", class(x)[[1L]],
     call. = FALSE)
@@ -56,8 +56,8 @@ docs_bulk_update.data.frame <- make_bulk_df_generator(make_bulk_update)
 
 # helpers
 make_bulk_update <- function(df, index, counter, type = NULL, path = NULL,
-  digits = NA) {
-  
+  digits = NA, sf = NULL) {
+
   if (!is.character(counter)) {
     if (max(counter) >= 10000000000) {
       scipen <- getOption("scipen")
@@ -87,7 +87,7 @@ make_bulk_update <- function(df, index, counter, type = NULL, path = NULL,
   data <- lapply(seq_len(nrow(df)), function(i) {
     z <- list(doc = jsonlite::unbox(df[i,,drop=FALSE]), doc_as_upsert = TRUE)
     jsonlite::toJSON(z, auto_unbox = TRUE, na = "null", null = "null",
-      digits = digits, sf = "features")
+      digits = digits, sf = sf)
   })
 
   tmpf <- if (is.null(path)) tempfile("elastic__") else path

--- a/R/docs_bulk_utils.R
+++ b/R/docs_bulk_utils.R
@@ -17,7 +17,7 @@ make_bulk <- function(df, index, counter, es_ids, type = NULL, path = NULL,
       sprintf(metadata_fmt, action, index, counter)
     }
     data <- jsonlite::toJSON(df, collapse = FALSE, na = "null",
-      auto_unbox = TRUE, digits = digits)
+      auto_unbox = TRUE, digits = digits, sf = "features")
     towrite <- paste(metadata, data, sep = "\n")
   } else {
     towrite <- unlist(unname(Map(function(a, b) {
@@ -30,7 +30,7 @@ make_bulk <- function(df, index, counter, es_ids, type = NULL, path = NULL,
       is_update <- a$es_action == "update"
       a$es_action <- NULL
       dat <- jsonlite::toJSON(a, collapse = FALSE, na = "null",
-        auto_unbox = TRUE, digits = digits)
+        auto_unbox = TRUE, digits = digits, sf = "features")
       if (is_update) dat <- sprintf('{"doc": %s, "doc_as_upsert": true}', dat)
       c(tmp, dat)
     }, split(df, seq_along(df)), counter)))

--- a/R/docs_bulk_utils.R
+++ b/R/docs_bulk_utils.R
@@ -1,5 +1,5 @@
-make_bulk <- function(df, index, counter, es_ids, type = NULL, path = NULL, 
-  digits = NA) {
+make_bulk <- function(df, index, counter, es_ids, type = NULL, path = NULL,
+  digits = NA, sf = NULL) {
 
   if (!is.character(counter)) {
     if (max(counter) >= 10000000000) {
@@ -17,7 +17,7 @@ make_bulk <- function(df, index, counter, es_ids, type = NULL, path = NULL,
       sprintf(metadata_fmt, action, index, counter)
     }
     data <- jsonlite::toJSON(df, collapse = FALSE, na = "null",
-      auto_unbox = TRUE, digits = digits, sf = "features")
+      auto_unbox = TRUE, digits = digits, sf = sf)
     towrite <- paste(metadata, data, sep = "\n")
   } else {
     towrite <- unlist(unname(Map(function(a, b) {
@@ -30,7 +30,7 @@ make_bulk <- function(df, index, counter, es_ids, type = NULL, path = NULL,
       is_update <- a$es_action == "update"
       a$es_action <- NULL
       dat <- jsonlite::toJSON(a, collapse = FALSE, na = "null",
-        auto_unbox = TRUE, digits = digits, sf = "features")
+        auto_unbox = TRUE, digits = digits, sf = sf)
       if (is_update) dat <- sprintf('{"doc": %s, "doc_as_upsert": true}', dat)
       c(tmp, dat)
     }, split(df, seq_along(df)), counter)))
@@ -50,7 +50,7 @@ make_metadata <- function(es_ids, counter, type) {
       } else {
         '{"%s":{"_index":"%s","_type":"%s","_id":%s}}'
       }
-    }    
+    }
   } else {
     if (es_ids) {
       '{"%s":{"_index":"%s"}}'
@@ -77,10 +77,10 @@ check_doc_ids <- function(x, ids) {
   if (!is.null(ids)) {
     # check class type
     if (!class(ids) %in% c('character', 'factor', 'numeric', 'integer')) {
-      stop("doc_ids must be of class character, numeric or integer", 
+      stop("doc_ids must be of class character, numeric or integer",
            call. = FALSE)
     }
-    
+
     # check appropriate length
     if (!all(1:NROW(x) == 1:length(ids))) {
       stop("doc_ids length must equal number of documents", call. = FALSE)
@@ -106,7 +106,7 @@ has_ids <- function(x) {
 
 close_conns <- function() {
   cons <- showConnections()
-  ours <- as.integer(rownames(cons)[grepl("/elastic__", cons[, "description"], 
+  ours <- as.integer(rownames(cons)[grepl("/elastic__", cons[, "description"],
                                           fixed = TRUE)])
   for (i in ours) {
     close(getConnection(i))

--- a/man/docs_bulk.Rd
+++ b/man/docs_bulk.Rd
@@ -16,6 +16,7 @@ docs_bulk(
   quiet = FALSE,
   query = list(),
   digits = NA,
+  sf = NULL,
   ...
 )
 }
@@ -59,6 +60,9 @@ ES page for details}
 \item{digits}{digits used by the parameter of the same name by
 \code{\link[jsonlite:fromJSON]{jsonlite::toJSON()}} to convert data to JSON before being submitted to
 your ES instance. default: \code{NA}}
+
+\item{sf}{used by \code{\link[jsonlite:fromJSON]{jsonlite::toJSON()}} to convert sf objects.
+Set to "features" for conversion to GeoJSON. default: "dataframe"}
 
 \item{...}{Pass on curl options to \link[crul:HttpClient]{crul::HttpClient}}
 }
@@ -253,7 +257,7 @@ index_delete(x, db)
 ## make sure you use a column named 'es_action' or this won't work
 ## if you need to delete or update you need document IDs
 if (index_exists(x, "baz")) index_delete(x, "baz")
-df <- data.frame(a = 1:5, b = 6:10, c = letters[1:5], stringsAsFactors = FALSE) 
+df <- data.frame(a = 1:5, b = 6:10, c = letters[1:5], stringsAsFactors = FALSE)
 invisible(docs_bulk(x, df, "baz"))
 Sys.sleep(3)
 (res <- Search(x, 'baz', asdf=TRUE)$hits$hits)
@@ -279,7 +283,7 @@ invisible(docs_bulk(x, plosdat, verbose = TRUE))
 
 # suppress progress bar
 invisible(docs_bulk(x, mtcars, index = "hello", quiet = TRUE))
-## vs. 
+## vs.
 invisible(docs_bulk(x, mtcars, index = "hello", quiet = FALSE))
 }
 }

--- a/man/docs_bulk_delete.Rd
+++ b/man/docs_bulk_delete.Rd
@@ -15,6 +15,7 @@ docs_bulk_delete(
   quiet = FALSE,
   query = list(),
   digits = NA,
+  sf = NULL,
   ...
 )
 }
@@ -51,7 +52,7 @@ options include: pipeline, refresh, routing, _source, _source_excludes,
 _source_includes, timeout, wait_for_active_shards. See the docs bulk
 ES page for details}
 
-\item{digits}{ignored, used in other docs bulk functions but not used here}
+\item{digits, sf}{ignored, used in other docs bulk functions but not used here}
 
 \item{...}{Pass on curl options to \link[crul:HttpClient]{crul::HttpClient}}
 }

--- a/man/docs_bulk_index.Rd
+++ b/man/docs_bulk_index.Rd
@@ -16,6 +16,7 @@ docs_bulk_index(
   quiet = FALSE,
   query = list(),
   digits = NA,
+  sf = NULL,
   ...
 )
 }
@@ -59,6 +60,9 @@ ES page for details}
 \item{digits}{digits used by the parameter of the same name by
 \code{\link[jsonlite:fromJSON]{jsonlite::toJSON()}} to convert data to JSON before being submitted to
 your ES instance. default: \code{NA}}
+
+\item{sf}{used by \code{\link[jsonlite:fromJSON]{jsonlite::toJSON()}} to convert sf objects.
+Set to "features" for conversion to GeoJSON. default: "dataframe"}
 
 \item{...}{Pass on curl options to \link[crul:HttpClient]{crul::HttpClient}}
 }

--- a/man/docs_bulk_prep.Rd
+++ b/man/docs_bulk_prep.Rd
@@ -12,7 +12,8 @@ docs_bulk_prep(
   chunk_size = 1000,
   doc_ids = NULL,
   quiet = FALSE,
-  digits = NA
+  digits = NA,
+  sf = NULL
 )
 }
 \arguments{
@@ -44,6 +45,9 @@ character. Default: not passed}
 \item{digits}{digits used by the parameter of the same name by
 \code{\link[jsonlite:fromJSON]{jsonlite::toJSON()}} to convert data to JSON before being submitted to
 your ES instance. default: \code{NA}}
+
+\item{sf}{used by \code{\link[jsonlite:fromJSON]{jsonlite::toJSON()}} to convert sf objects.
+Set to "features" for conversion to GeoJSON. default: "dataframe"}
 }
 \value{
 File path(s). By default we use temporary files; these are cleaned
@@ -147,7 +151,7 @@ unlist(paths)
 ## make sure you use a column named 'es_action' or this won't work
 ## if you need to delete or update you need document IDs
 if (index_exists(x, "baz")) index_delete(x, "baz")
-df <- data.frame(a = 1:5, b = 6:10, c = letters[1:5], stringsAsFactors = FALSE) 
+df <- data.frame(a = 1:5, b = 6:10, c = letters[1:5], stringsAsFactors = FALSE)
 f <- tempfile(fileext = ".json")
 invisible(docs_bulk_prep(df, "baz", f))
 cat(readLines(f), sep = "\n")
@@ -171,7 +175,7 @@ docs_bulk(x, f)
 # suppress progress bar
 docs_bulk_prep(mtcars, index = "hello",
   path = tempfile(fileext = ".json"), quiet = TRUE)
-## vs. 
+## vs.
 docs_bulk_prep(mtcars, index = "hello",
   path = tempfile(fileext = ".json"), quiet = FALSE)
 }

--- a/man/docs_bulk_update.Rd
+++ b/man/docs_bulk_update.Rd
@@ -15,6 +15,7 @@ docs_bulk_update(
   quiet = FALSE,
   query = list(),
   digits = NA,
+  sf = NULL,
   ...
 )
 }
@@ -54,6 +55,9 @@ ES page for details}
 \item{digits}{digits used by the parameter of the same name by
 \code{\link[jsonlite:fromJSON]{jsonlite::toJSON()}} to convert data to JSON before being submitted to
 your ES instance. default: \code{NA}}
+
+\item{sf}{used by \code{\link[jsonlite:fromJSON]{jsonlite::toJSON()}} to convert sf objects.
+Set to "features" for conversion to GeoJSON. default: "dataframe"}
 
 \item{...}{Pass on curl options to \link[crul:HttpClient]{crul::HttpClient}}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With this change 'sf' objects are converted to geojson when using `docs_bulk_*()`, which is possible since jsonlite 1.7.0.
No changes for all other kinds of inputs as far as I can tell.
This is a feature I need for my work when storing geodata in Elastic and to perform geo queries later. Hope other people find this useful too!

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
With a mapping, you can use geo queries:
```
library(sf)

conn <- connect()
index <- "test"

sf <- read_sf(system.file("gpkg/nc.gpkg", package = "sf"))

index_create(conn, index)
# Elastic Version 8.4.1
mapping_create(conn, index, body = list(
  properties = list(geometry = list(type = "geo_shape"))
))

docs_bulk_index(conn, sf, index)

Sys.sleep(1)

Search(conn, index, body = list(
  query = list(
    bool = list(
      must = list(
        match_all = c()
      ),
      filter = list(
        geo_shape = list(
          geometry = list(
            relation = "intersects",
            shape = list(
              type = "point",
              coordinates = c(-79.40065, 35.55937)
            )
          )
        )
      )
    )
  )
))
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
