### PR TITLE
fix #288, and similar issue in docs_bulk_prep

### DIFF
--- a/R/bulk_ci_generator.R
+++ b/R/bulk_ci_generator.R
@@ -10,9 +10,17 @@ make_bulk_ <- function(df, index, counter, es_ids, type = NULL, path = NULL,
   }
   metadata_fmt <- make_metadata(es_ids, counter, type)
   metadata <- if (!is.null(type)) {
-    sprintf(metadata_fmt, action, index, type, counter)
+    if (!es_ids) {
+      sprintf(metadata_fmt, action, index, type, counter) 
+    } else {
+      sprintf(metadata_fmt, action, index, type)
+    }
   } else {
-    sprintf(metadata_fmt, action, index, counter)
+    if (!es_ids) {
+      sprintf(metadata_fmt, action, index, counter) 
+    } else {
+      sprintf(metadata_fmt, action, index)
+    }
   }
   data <- jsonlite::toJSON(df, collapse = FALSE, na = "null",
     auto_unbox = TRUE, digits = digits, sf = sf)

--- a/R/docs_bulk_prep.R
+++ b/R/docs_bulk_prep.R
@@ -151,7 +151,7 @@ docs_bulk_prep.data.frame <- function(x, index, path, type = NULL,
 
   assert(quiet, "logical")
   check_doc_ids(x, doc_ids)
-  es_ids <- if (!is.null(doc_ids)) FALSE else TRUE
+  es_ids <- if (is.null(doc_ids)) FALSE else TRUE
   if (is.factor(doc_ids)) doc_ids <- as.character(doc_ids)
   row.names(x) <- NULL
   rws <- seq_len(NROW(x))
@@ -188,7 +188,7 @@ docs_bulk_prep.list <- function(x, index, path, type = NULL,
 
   assert(quiet, "logical")
   check_doc_ids(x, doc_ids)
-  es_ids <- if (!is.null(doc_ids)) TRUE else FALSE
+  es_ids <- if (is.null(doc_ids)) TRUE else FALSE
   if (is.factor(doc_ids)) doc_ids <- as.character(doc_ids)
   x <- unname(x)
   x <- check_named_vectors(x)

--- a/R/docs_bulk_utils.R
+++ b/R/docs_bulk_utils.R
@@ -12,9 +12,17 @@ make_bulk <- function(df, index, counter, es_ids, type = NULL, path = NULL,
   if (!"es_action" %in% names(df)) {
     action <- "index"
     metadata <- if (!is.null(type)) {
-      sprintf(metadata_fmt, action, index, type, counter)
+      if (!es_ids) {
+        sprintf(metadata_fmt, action, index, type, counter) 
+      } else {
+        sprintf(metadata_fmt, action, index, type)
+      }
     } else {
-      sprintf(metadata_fmt, action, index, counter)
+      if (!es_ids) {
+        sprintf(metadata_fmt, action, index, counter) 
+      } else {
+        sprintf(metadata_fmt, action, index)
+      }
     }
     data <- jsonlite::toJSON(df, collapse = FALSE, na = "null",
       auto_unbox = TRUE, digits = digits, sf = sf)
@@ -22,9 +30,17 @@ make_bulk <- function(df, index, counter, es_ids, type = NULL, path = NULL,
   } else {
     towrite <- unlist(unname(Map(function(a, b) {
       tmp <- if (!is.null(type)) {
-        sprintf(metadata_fmt, a$es_action, index, type, b)
+        if (!es_ids) {
+          sprintf(metadata_fmt, a$es_action, index, type, b) 
+        } else {
+          sprintf(metadata_fmt, a$es_action, index, type)
+        }
       } else {
-        sprintf(metadata_fmt, a$es_action, index, b)
+        if (!es_ids) {
+          sprintf(metadata_fmt, a$es_action, index, b) 
+        } else {
+          sprintf(metadata_fmt, a$es_action, index)
+        }
       }
       if (a$es_action == "delete") return(tmp)
       is_update <- a$es_action == "update"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Minor fixes pertaining to the `es_ids` setting. 
In  `docs_bulk_prep` I believe the boolean was given the wrong value.
In other bulk-context the fixes will eliminate a warning thrown by `sprintf`. 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
fix #288

